### PR TITLE
Change Object to BaseObject

### DIFF
--- a/models/User.php
+++ b/models/User.php
@@ -4,7 +4,7 @@ namespace app\models;
 
 use carono\exchange1c\interfaces\PartnerInterface;
 
-class User extends \yii\base\Object implements \yii\web\IdentityInterface, PartnerInterface
+class User extends \yii\base\BaseObject implements \yii\web\IdentityInterface, PartnerInterface
 {
     public $id;
     public $username;


### PR DESCRIPTION
fix for Yii 2.0.13 (in php 7.2 Object - is reserved letter)